### PR TITLE
fix: CSS Theme on mobile view

### DIFF
--- a/src/components/TokenList/index.js
+++ b/src/components/TokenList/index.js
@@ -215,12 +215,10 @@ function TopTokenList({ tokens, itemMax = 10 }) {
       <DashGrid center={true} style={{ height: 'fit-content', padding: '0 1.125rem 1rem 1.125rem' }}>
         <Flex alignItems="center" justifyContent="flexStart">
           <ClickableText
-            color="text"
             area="name"
-            fontWeight="500"
             onClick={(e) => {
               setSortedColumn(SORT_FIELD.NAME)
-              setSortDirection(sortedColumn !== SORT_FIELD.NAMe ? true : !sortDirection)
+              setSortDirection(sortedColumn !== SORT_FIELD.NAME ? true : !sortDirection)
             }}
           >
             {below680 ? 'Symbol' : 'Name'} {sortedColumn === SORT_FIELD.NAME ? (!sortDirection ? '↑' : '↓') : ''}


### PR DESCRIPTION
Fix a CSS class behind applied on Token name/symbol; instead of using current theme.